### PR TITLE
fix: cicd pipeline nodejs version to 10

### DIFF
--- a/backend/buildspec-integ-test.yaml
+++ b/backend/buildspec-integ-test.yaml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 12
+      nodejs: 10
     commands:
       - npm install -g @vue/cli
   build

--- a/backend/buildspec.yaml
+++ b/backend/buildspec.yaml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 12
+      nodejs: 10
   build:
     commands:
       - ./backend/bin/package-backend.sh

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 12
+      nodejs: 10
     commands:
       - npm install -g @vue/cli
   build:

--- a/frontend/buildspec-integ-test.yaml
+++ b/frontend/buildspec-integ-test.yaml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 12
+      nodejs: 10
     commands:
       - npm install -g @vue/cli
   build:

--- a/frontend/buildspec.yaml
+++ b/frontend/buildspec.yaml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 12
+      nodejs: 10
     commands:
       - npm install -g @vue/cli
   build:


### PR DESCRIPTION
Fixing buildspec.yaml and buildspec-integ-test.yaml to compatible nodejs version 10